### PR TITLE
Fix number parsing in demo service

### DIFF
--- a/app/services/demo_service/app.py
+++ b/app/services/demo_service/app.py
@@ -19,6 +19,9 @@ running_tests = {}
 def run_k6_test(test_type, duration=60, vus=5):
     """Run K6 test in Docker container"""
     try:
+        # Ensure numeric values for calculations
+        duration = int(duration)
+        vus = int(vus)
         if test_type == 'load-testing':
             cmd = [
                 'docker', 'exec', 'k6-load-tester', 
@@ -82,8 +85,8 @@ def start_load_testing():
             # If JSON parsing fails, use defaults
             pass
         
-        duration = data.get('duration', 60)
-        vus = data.get('vus', 5)
+        duration = int(data.get('duration', 60))
+        vus = int(data.get('vus', 5))
         
         if 'load-testing' in running_tests and running_tests['load-testing']['status'] == 'running':
             return jsonify({


### PR DESCRIPTION
## Summary
- ensure duration and VU values are parsed as integers in the demo service
- convert parameters inside `run_k6_test` for reliable math

## Testing
- `python3 -m py_compile app/services/demo_service/app.py`
- `pytest -q` *(fails: ImportError: cannot import name 'computed_field' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684202dde6b0832c9a342b50ed10723d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of load testing by ensuring the duration and number of virtual users are always processed as numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->